### PR TITLE
Use Buffer.from when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 module.exports = toBuffer
 
+function convert (buf, enc) {
+  return Buffer.from ? Buffer.from(buf, enc) : new Buffer(buf, enc)
+}
+
 function toBuffer (buf, enc) {
   if (Buffer.isBuffer(buf)) return buf
-  if (typeof buf === 'string') return new Buffer(buf, enc)
-  if (Array.isArray(buf)) return new Buffer(buf)
+  if (typeof buf === 'string') return convert(buf, enc)
+  if (Array.isArray(buf)) return convert(buf)
   throw new Error('Input should be a buffer or a string')
 }


### PR DESCRIPTION
`new Buffer()` doesn't work on Node 6+, so we use the new stuff when possible and fall back otherwise.